### PR TITLE
added the installation of the test directory

### DIFF
--- a/choreonoid_plugins/CMakeLists.txt
+++ b/choreonoid_plugins/CMakeLists.txt
@@ -168,6 +168,11 @@ install(TARGETS
   ARCHIVE DESTINATION ${CNOID_PLUGIN_SUBDIR}
 )
 
+install(
+  DIRECTORY test
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
 if(ENABLE_PYTHON)
   add_subdirectory(src/python)
 endif()


### PR DESCRIPTION
install/share/choreonoid_plugins へ test ディレクトリがインストールされていない事により、Choreonoid ROSプラグインチュートリアルの roslaunch choreonoid_ros jvrc-1-rviz.launch を実行すると、src/choreonoid_ros_pkg/choreonoid_plugins/test/jvrc1-O1.cnoid の方が読み込まれ、プロジェクトファイル内で相対パスで指定されているモデルも src/choreonoid_ros_pkg/jvrc_models の方が読み込まれます。

チュートリアルの実施においては問題は無いのですが、モデルの修正を試行したい場合などに、install 以下で作業が出来ず少し不便なので、本リクエストを投げる次第です。
