### PR TITLE
renewal for the joints controller

### DIFF
--- a/choreonoid_plugins/CMakeLists.txt
+++ b/choreonoid_plugins/CMakeLists.txt
@@ -158,7 +158,16 @@ if(ENABLE_PYTHON)
 endif()
 
 ## Plugins
-add_cnoid_plugin(CnoidRosBodyPlugin SHARED src/RosBodyPlugin.cpp src/BodyRosItem.cpp src/WorldRosItem.cpp)
+add_cnoid_plugin(CnoidRosBodyPlugin
+  SHARED
+  src/RosBodyPlugin.cpp
+  src/BodyRosItem.cpp
+  src/WorldRosItem.cpp
+  src/BodyRosJointControllerItem.cpp
+  src/BodyRosTorqueControllerItem.cpp
+  src/BodyRosHighgainControllerItem.cpp
+)
+
 target_link_libraries(CnoidRosBodyPlugin ${CNOID_LIBRARIES} CnoidBodyPlugin ${catkin_LIBRARIES})
 
 install(TARGETS 

--- a/choreonoid_plugins/src/BodyRosHighgainControllerItem.cpp
+++ b/choreonoid_plugins/src/BodyRosHighgainControllerItem.cpp
@@ -1,0 +1,183 @@
+/**
+  @file
+  @author
+ */
+
+#include "BodyRosHighgainControllerItem.h"
+
+using namespace cnoid;
+
+void BodyRosHighgainControllerItem::initialize(ExtensionManager* ext) { 
+  static bool initialized = false;
+  int argc = 0;
+  char** argv;
+
+  if (! ros::isInitialized()) {
+    ros::init(argc, argv, "choreonoid");
+  }
+
+  if (! initialized) {
+    ext->itemManager().registerClass<BodyRosHighgainControllerItem>("BodyRosHighgainControllerItem");
+    ext->itemManager().addCreationPanel<BodyRosHighgainControllerItem>();
+    initialized = true;
+  }
+}
+
+BodyRosHighgainControllerItem::BodyRosHighgainControllerItem()
+{
+  controllerTarget         = 0;
+  control_mode_name_       = "highgain_control";
+  has_trajectory_          = false;
+  joint_state_update_rate_ = 100.0;
+}
+
+BodyRosHighgainControllerItem::BodyRosHighgainControllerItem(const BodyRosHighgainControllerItem& org)
+  : BodyRosJointControllerItem(org)
+{
+  controllerTarget         = 0;
+  control_mode_name_       = "highgain_control";
+  has_trajectory_          = false;
+  joint_state_update_rate_ = 100.0;
+}
+
+BodyRosHighgainControllerItem::~BodyRosHighgainControllerItem()
+{
+  stop();
+}
+
+Item* BodyRosHighgainControllerItem::doDuplicate() const
+{
+  return new BodyRosHighgainControllerItem(*this);
+}
+
+bool BodyRosHighgainControllerItem::hook_of_start()
+{
+  timeStep2_ = timeStep_ * timeStep_;
+
+  return true;
+}
+
+void BodyRosHighgainControllerItem::apply_message(Link* joint, size_t idx, trajectory_msgs::JointTrajectoryPoint* point)
+{
+  double q;
+  double dq;
+  double ddq;
+  size_t i;
+
+  if (! joint || ! point) {
+    ROS_ERROR("%s: Invalid arguments", __PRETTY_FUNCTION__);
+    return;
+  }
+
+  ROS_DEBUG("----- %s (joint id %d) -----", joint->name().c_str(), joint->jointId());
+
+  i = joint->jointId();
+  q = point->positions[idx];
+
+  if (isnan(q)) {
+    ROS_ERROR("Joint angle setting is NaN (%s)", joint->name().c_str());
+    return;
+  } else if (q < joint->q_lower() || q > joint->q_upper()) {
+    ROS_ERROR("Joint angle setting is over limit (%s: lower %f upper %f set %f)",
+              joint->name().c_str(), joint->q_lower(), joint->q_upper(), q);
+    return;
+  }
+
+  if (point->velocities.size() > 0) {
+    dq = point->velocities[idx];
+  } else {
+    dq = (q - joint->q()) / timeStep_;
+  }
+
+  if (isnan(dq)) {
+    ROS_ERROR("Joint velocity setting is NaN (%s)", joint->name().c_str());
+    return;
+  } else if (dq < joint->dq_lower()) {
+    ROS_DEBUG("Calculate dq, result is over lower limt. (adjust %f -> %f)", dq, joint->dq_lower());
+    dq = joint->dq_lower();
+  } else if (dq > joint->dq_upper()) {
+    ROS_DEBUG("Calculate dq, result is over upper limt. (adjust %f -> %f)", dq, joint->dq_upper());
+    dq = joint->dq_upper();
+  }
+
+  if (point->accelerations.size() > 0) {
+    ddq = point->accelerations[idx];
+  } else {
+    ddq = (q - joint->q()) / timeStep2_;
+  }
+
+  if (isnan(ddq)) {
+    ROS_ERROR("Joint acceleration setting is NaN (%s)", joint->name().c_str());
+    return;
+  } else if (ddq < joint->dq_lower()) {
+    ROS_DEBUG("Calculate ddq, result is over lower limt. (adjust %f -> %f)", ddq, joint->dq_lower());
+    ddq = joint->dq_lower();
+  } else if (ddq > joint->dq_upper()) {
+    ROS_DEBUG("Calculate ddq, result is over lower limt. (adjust %f -> %f)", ddq, joint->dq_lower());
+    ddq = joint->dq_upper();
+  }
+
+  ROS_DEBUG("q %f dq %f ddq %f q_old %f", q, dq, ddq, joint->q());
+
+  joint->q()   = q;
+  joint->dq()  = dq;
+  joint->ddq() = ddq;
+
+  return;
+}
+
+bool BodyRosHighgainControllerItem::copy_message(
+      const trajectory_msgs::JointTrajectoryPoint* msg,
+      trajectory_msgs::JointTrajectoryPoint* dst,
+      size_t idx,
+      unsigned int jsz
+      )
+{
+  bool has_vel;
+  bool has_accel;
+
+  if (! msg || ! dst || jsz < 1) {
+    ROS_ERROR("%s: Invalid arguments", __PRETTY_FUNCTION__);
+    return false;
+  }
+
+  if (msg->effort.size() > 0) {
+    ROS_WARN("Can not setting effort in this high-gain controller");
+    return false;
+  }
+
+  dst->positions.resize(jsz);
+
+  if (msg->velocities.size() > 0) {
+    dst->velocities.resize(jsz);
+    has_vel = true;
+  } else {
+    dst->velocities.resize(0);
+    has_vel = false;
+  }
+
+  if (msg->accelerations.size() > 0) {
+    dst->accelerations.resize(jsz);
+    has_accel = true;
+  } else {
+    dst->accelerations.resize(0);
+    has_accel = false;
+  }
+
+  for (size_t i = 0; i < jsz; i++) {
+    dst->positions[i] = (i < msg->positions.size()) ? msg->positions[i] : 0.0;
+
+    if (has_vel) {
+      dst->velocities[i] = (i < msg->velocities.size()) ? msg->velocities[i] : 0.0;
+    }
+
+    if (has_accel) {
+      dst->accelerations[i] = (i < msg->accelerations.size()) ? msg->accelerations[i] : 0.0;
+    }
+  }
+
+  dst->time_from_start = ros::Duration(msg->time_from_start.sec, msg->time_from_start.nsec);
+
+  return true;
+}
+

--- a/choreonoid_plugins/src/BodyRosHighgainControllerItem.h
+++ b/choreonoid_plugins/src/BodyRosHighgainControllerItem.h
@@ -1,0 +1,40 @@
+/**
+  @file
+  @author
+ */
+
+#ifndef CNOID_ROS_PLUGIN_BODY_ROS_HIGHGAIN_CONTROLLER_ITEM_H_INCLUDED
+#define CNOID_ROS_PLUGIN_BODY_ROS_HIGHGAIN_CONTROLLER_ITEM_H_INCLUDED
+
+#include "BodyRosJointControllerItem.h"
+
+namespace cnoid {
+
+class CNOID_EXPORT BodyRosHighgainControllerItem : public BodyRosJointControllerItem
+{
+public:
+    static void initialize(ExtensionManager* ext);
+
+    BodyRosHighgainControllerItem();
+    BodyRosHighgainControllerItem(const BodyRosHighgainControllerItem& org);
+    virtual ~BodyRosHighgainControllerItem();
+
+protected:
+    virtual Item* doDuplicate() const;
+    virtual bool hook_of_start();
+    virtual void apply_message(Link* joint, size_t idx, trajectory_msgs::JointTrajectoryPoint* point);
+    virtual bool copy_message(
+                  const trajectory_msgs::JointTrajectoryPoint* msg,
+                  trajectory_msgs::JointTrajectoryPoint* dst,
+                  size_t idx,
+                  unsigned int jsz
+                  );
+
+private:
+    double timeStep2_;
+};
+
+typedef ref_ptr<BodyRosHighgainControllerItem> BodyRosHighgainControllerItemPtr;
+}
+
+#endif  /* CNOID_ROS_PLUGIN_BODY_ROS_HIGHGAIN_CONTROLLER_ITEM_H_INCLUDED */

--- a/choreonoid_plugins/src/BodyRosItem.h
+++ b/choreonoid_plugins/src/BodyRosItem.h
@@ -19,7 +19,7 @@
 #include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/LaserScan.h>
 #include <geometry_msgs/Wrench.h>
-#include <trajectory_msgs/JointTrajectory.h>
+
 #include <image_transport/image_transport.h>
 
 #include <vector>
@@ -45,8 +45,6 @@ public:
     virtual bool control();
     virtual void output();
     virtual void stop();
-    
-    void callback(const trajectory_msgs::JointTrajectory::ConstPtr& msg);
     
     const BodyPtr& body() const { return simulationBody; };
     const DeviceList<ForceSensor>& forceSensors() const { return forceSensors_; }
@@ -81,19 +79,6 @@ private:
 
     boost::shared_ptr<ros::NodeHandle> rosnode_;
     boost::shared_ptr<ros::AsyncSpinner> async_ros_spin_;
-    sensor_msgs::JointState joint_state_;
-    ros::Publisher joint_state_publisher_;
-    ros::Subscriber joint_state_subscriber_;
-    double joint_state_update_rate_;
-    double joint_state_update_period_;
-    double joint_state_last_update_;
-    
-    std::map<std::string, int> joint_number_map_;
-    std::vector<std::string> joint_names_;
-    std::vector<trajectory_msgs::JointTrajectoryPoint> points_;
-    double trajectory_start_;
-    unsigned int trajectory_index_;
-    bool has_trajectory_;
  
     std::vector<ros::Publisher> force_sensor_publishers_;
     std::vector<ros::Publisher> rate_gyro_sensor_publishers_;

--- a/choreonoid_plugins/src/BodyRosJointControllerItem.cpp
+++ b/choreonoid_plugins/src/BodyRosJointControllerItem.cpp
@@ -1,0 +1,287 @@
+/**
+  @file
+  @author
+ */
+
+#include "BodyRosJointControllerItem.h"
+
+using namespace cnoid;
+
+BodyRosJointControllerItem::BodyRosJointControllerItem()
+  : os(MessageView::instance()->cout())
+{
+  controllerTarget         = 0;
+  control_mode_name_       = "";
+  has_trajectory_          = false;
+  joint_state_update_rate_ = 100.0;
+}
+
+BodyRosJointControllerItem::BodyRosJointControllerItem(const BodyRosJointControllerItem& org)
+  : ControllerItem(org),
+    os(MessageView::instance()->cout())
+{
+  controllerTarget         = 0;
+  control_mode_name_       = "";
+  has_trajectory_          = false;
+  joint_state_update_rate_ = 100.0;
+}
+
+BodyRosJointControllerItem::~BodyRosJointControllerItem()
+{
+  stop();
+}
+
+Item* BodyRosJointControllerItem::doDuplicate() const
+{
+  return new BodyRosJointControllerItem(*this);
+}
+
+void BodyRosJointControllerItem::doPutProperties(PutPropertyFunction& putProperty)
+{
+  putProperty.decimals(2).min(0.0)("Update rate", joint_state_update_rate_, changeProperty(joint_state_update_rate_));
+}
+
+bool BodyRosJointControllerItem::hook_of_start()
+{
+#if (DEBUG_ROS_JOINT_CONTROLLER > 0)
+  ROS_DEBUG("%s: Called", __PRETTY_FUNCTION__);
+#endif  /* DEBUG_ROS_JOINT_CONTROLLER */
+
+  return true;
+}
+
+bool BodyRosJointControllerItem::start(Target* target)
+{
+  std::string topic_name;
+
+  if (! target) {
+    MessageView::instance()->putln(MessageView::ERROR, boost::format("Target not found"));
+    return false;
+  } else if (! target->body()) {
+    MessageView::instance()->putln(MessageView::ERROR, boost::format("BodyItem not found"));
+    return false;
+  } else if (control_mode_name_.empty()) {
+    ROS_ERROR("%s: control_mode_name_ is empty, please report to developer", __PRETTY_FUNCTION__);
+    return false;
+  } else {
+    std::replace(control_mode_name_.begin(), control_mode_name_.end(), '-', '_');
+  }
+
+  controllerTarget = target;
+  simulationBody   = target->body();
+  timeStep_        = target->worldTimeStep();
+  controlTime_     = target->currentTime();
+
+  // buffer of preserve currently state of joints.
+  joint_state_.header.stamp.fromSec(controlTime_);
+  joint_state_.name.resize(body()->numJoints());
+  joint_state_.position.resize(body()->numJoints());
+  joint_state_.velocity.resize(body()->numJoints());
+  joint_state_.effort.resize(body()->numJoints());
+
+  // preserve initial state of joints.
+  for (size_t i = 0; i < body()->numJoints(); i++) {
+    Link* joint = body()->joint(i);
+
+    joint_number_map_[ joint->name() ] = i;
+    joint_state_.name[i]               = joint->name();
+    joint_state_.position[i]           = joint->q();
+    joint_state_.velocity[i]           = joint->dq();
+    joint_state_.effort[i]             = joint->u();
+  }
+
+  std::string name = body()->name();
+  std::replace(name.begin(), name.end(), '-', '_');
+
+  if (hook_of_start() == false) {
+    return false;
+  }
+
+  rosnode_ = boost::shared_ptr<ros::NodeHandle>(new ros::NodeHandle(name));
+
+  topic_name                 = control_mode_name_ + "/joint_states";
+  joint_state_publisher_     = rosnode_->advertise<sensor_msgs::JointState>(topic_name, 1000);
+  topic_name                 = control_mode_name_ + "/set_joint_trajectory";
+  joint_state_subscriber_    = rosnode_->subscribe(
+                                          topic_name, 1000, &BodyRosJointControllerItem::receive_message, this);
+  joint_state_update_period_ = 1.0 / joint_state_update_rate_;
+  joint_state_last_update_   = controllerTarget->currentTime();
+
+  ROS_DEBUG("Joint state update rate %f", joint_state_update_rate_);
+
+  async_ros_spin_.reset(new ros::AsyncSpinner(0));
+  async_ros_spin_->start();
+
+  return true;
+}
+
+void BodyRosJointControllerItem::apply_message(Link* joint, size_t idx, trajectory_msgs::JointTrajectoryPoint* point)
+{
+#if (DEBUG_ROS_JOINT_CONTROLLER > 0)
+  ROS_DEBUG("%s: Called", __PRETTY_FUNCTION__);
+#endif  /* DEBUG_ROS_JOINT_CONTROLLER */
+
+  return;
+}
+
+void BodyRosJointControllerItem::keep_attitude()
+{
+#if (DEBUG_ROS_JOINT_CONTROLLER > 0)
+  ROS_DEBUG("%s: No operations", __PRETTY_FUNCTION__);
+#endif  /* DEBUG_ROS_JOINT_CONTROLLER */
+
+  return;
+}
+
+bool BodyRosJointControllerItem::control()
+{
+  controlTime_ = controllerTarget->currentTime();
+  double updateSince = controlTime_ - joint_state_last_update_;
+
+  if (updateSince > joint_state_update_period_) {
+    // publish current joint states
+    joint_state_.header.stamp.fromSec(controlTime_);
+
+    for (int i = 0; i < body()->numJoints(); i++) {
+      Link* joint = body()->joint(i);
+      joint_state_.position[i] = joint->q();
+      joint_state_.velocity[i] = joint->dq();
+      joint_state_.effort[i] = joint->u();
+    }
+
+    joint_state_publisher_.publish(joint_state_);
+    joint_state_last_update_ += joint_state_update_period_;
+  }
+
+  // apply joint force based on the trajectory message
+  if (has_trajectory_ && controlTime_ >= trajectory_start_) {
+    if (trajectory_index_ < points_.size()) {
+      unsigned int joint_size = joint_names_.size();
+
+      for (size_t i = 0; i < joint_size; ++i) {
+        std::map<std::string, int>::const_iterator it = joint_number_map_.find(joint_names_[i]);
+
+        if (it != joint_number_map_.end()) {
+          apply_message(body()->joint((*it).second), i, &points_[ trajectory_index_ ]);
+        } else {
+          ROS_WARN("Unknown joint name: %s", joint_names_[i].c_str());
+        }
+      }
+
+      ros::Duration duration(points_[trajectory_index_].time_from_start.sec,
+                             points_[trajectory_index_].time_from_start.nsec);
+      trajectory_start_ += duration.toSec();
+      trajectory_index_++;
+    } else {
+      has_trajectory_ = false;
+    }
+  }
+
+  keep_attitude();
+
+  return true;
+}
+
+void BodyRosJointControllerItem::input()
+{
+  return;
+}
+
+void BodyRosJointControllerItem::output()
+{
+  return;
+}
+
+void BodyRosJointControllerItem::stop()
+{
+  if (ros::ok()) {
+    if (async_ros_spin_) {
+      async_ros_spin_->stop();
+    }
+
+    if (rosnode_) {
+      rosnode_->shutdown();
+    }
+  }
+
+  return;
+}
+
+void BodyRosJointControllerItem::start_copy_message()
+{
+#if (DEBUG_ROS_JOINT_CONTROLLER > 0)
+  ROS_DEBUG("%s: Called", __PRETTY_FUNCTION__);
+#endif  /* DEBUG_ROS_JOINT_CONTROLLER */
+
+  return;
+}
+
+void BodyRosJointControllerItem::end_copy_message()
+{
+#if (DEBUG_ROS_JOINT_CONTROLLER > 0)
+  ROS_DEBUG("%s: Called", __PRETTY_FUNCTION__);
+#endif  /* DEBUG_ROS_JOINT_CONTROLLER */
+
+  return;
+}
+
+bool BodyRosJointControllerItem::copy_message(
+      const trajectory_msgs::JointTrajectoryPoint* msg,
+      trajectory_msgs::JointTrajectoryPoint* dst,
+      size_t idx,
+      unsigned int jsz
+      )
+{
+#if (DEBUG_ROS_JOINT_CONTROLLER > 0)
+  ROS_DEBUG("%s: No operations", __PRETTY_FUNCTION__);
+#endif  /* DEBUG_ROS_JOINT_CONTROLLER */
+
+  return false;
+}
+
+void BodyRosJointControllerItem::receive_message(const trajectory_msgs::JointTrajectory::ConstPtr& msg)
+{
+  // copy all the trajectory info to the buffer
+  unsigned int joint_size = msg->joint_names.size();
+
+  // just in case.
+  if (joint_size < 1) {
+    return;
+  }
+
+  joint_names_.resize(joint_size);
+  for (size_t i = 0; i < joint_size; ++i) {
+    joint_names_[i] = msg->joint_names[i];
+  }
+  unsigned int point_size = msg->points.size();
+
+  // just in case.
+  if (point_size < 1) {
+    joint_names_.resize(0);
+    return;
+  }
+
+  points_.resize(point_size);
+
+  start_copy_message();
+
+  for (size_t i = 0; i < point_size; ++i) {
+    if (! copy_message(&msg->points[i], &points_[i], i, joint_size)) {
+      return;
+    }
+  }
+
+  trajectory_start_ = ros::Time(msg->header.stamp.sec, msg->header.stamp.nsec).toSec();
+
+  if (trajectory_start_ < controlTime_) {
+    trajectory_start_ = controlTime_;
+  }
+
+  trajectory_index_ = 0;
+  has_trajectory_ = true;
+
+  end_copy_message();
+
+  return;
+}
+

--- a/choreonoid_plugins/src/BodyRosJointControllerItem.h
+++ b/choreonoid_plugins/src/BodyRosJointControllerItem.h
@@ -1,0 +1,172 @@
+/**
+  @file
+  @author
+ */
+
+#ifndef CNOID_ROS_PLUGIN_BODY_ROS_JOINT_CONTROLLER_ITEM_H_INCLUDED
+#define CNOID_ROS_PLUGIN_BODY_ROS_JOINT_CONTROLLER_ITEM_H_INCLUDED
+
+#include <cnoid/ControllerItem>
+#include <cnoid/Body>
+#include <cnoid/BodyItem>
+#include <cnoid/Link>
+#include <cnoid/ItemManager>
+#include <cnoid/MessageView>
+#include "exportdecl.h"
+
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <sensor_msgs/JointState.h>
+#include <sensor_msgs/Imu.h>
+#include <geometry_msgs/Wrench.h>
+#include <trajectory_msgs/JointTrajectory.h>
+
+#include <vector>
+
+#define DEBUG_ROS_JOINT_CONTROLLER 0
+
+namespace cnoid {
+
+class CNOID_EXPORT BodyRosJointControllerItem : public ControllerItem
+{
+public:
+    /**
+      @brief Constructor.
+     */
+    BodyRosJointControllerItem();
+
+    /**
+      @brief Copy constructor.
+     */
+    BodyRosJointControllerItem(const BodyRosJointControllerItem& org);
+
+    /**
+      @brief Destructor.
+     */
+    virtual ~BodyRosJointControllerItem();
+
+    void doPutProperties(PutPropertyFunction& putProperty);
+
+    virtual bool start(Target* target);
+
+    virtual double timeStep() const {
+      return timeStep_;
+    };
+
+    virtual void input();
+    virtual bool control();
+    virtual void output();
+    virtual void stop();
+
+    /**
+      @brief Receive joint trajectory message.
+      this method is callback method of joint state subscribe.
+      details joint trajectory message, see http://docs.ros.org/api/trajectory_msgs/html/msg/JointTrajectory.html
+      @param[in] msg Joint trajectory message.
+     */
+    void receive_message(const trajectory_msgs::JointTrajectory::ConstPtr& msg);
+
+    const BodyPtr& body() const {
+      return simulationBody;
+    };
+
+    double controlTime() const {
+      return controlTime_;
+    }
+
+    void setModuleName(const std::string& name);
+
+protected:
+    virtual Item* doDuplicate() const;
+
+    BodyPtr simulationBody;
+    double timeStep_;
+
+    const Target* controllerTarget;
+    double controlTime_;
+    std::ostream& os;
+
+    std::string bodyName;
+
+    boost::shared_ptr<ros::NodeHandle> rosnode_;
+    boost::shared_ptr<ros::AsyncSpinner> async_ros_spin_;
+
+    /**
+      execute publish and subscribe, by topic of /[model_name]/[control_mode_name_]/[topic_name].
+    */
+    std::string control_mode_name_;
+
+    sensor_msgs::JointState joint_state_;
+    ros::Publisher joint_state_publisher_;
+    ros::Subscriber joint_state_subscriber_;
+    double joint_state_update_rate_;
+    double joint_state_update_period_;
+    double joint_state_last_update_;
+
+    std::map<std::string, int> joint_number_map_;
+    std::vector<std::string> joint_names_;
+    std::vector<trajectory_msgs::JointTrajectoryPoint> points_;
+    double trajectory_start_;
+    unsigned int trajectory_index_;
+    bool has_trajectory_;
+
+    /*
+      @brief Hook of simulation start.
+      this method calling in BodyRosJointControllerItem::start.
+      @retval true Start controller.
+      @retval false Stop controller.
+     */
+    virtual bool hook_of_start();
+
+    /**
+      @brief Apply joint trajectory of inner buffer.
+      this method calling in BodyRosJointControllerItem::control.
+      @param[in] joint Pointer of joint. (cnoid::Link*)
+      @param[in] idx Index of joint.
+      this is trajectory message's joint index, not cnoid::Link::jointId().
+      @param[in] point Pointer of joint trajectory point message.
+      details see http://docs.ros.org/api/trajectory_msgs/html/msg/JointTrajectoryPoint.html
+     */
+    virtual void apply_message(Link* joint, size_t idx, trajectory_msgs::JointTrajectoryPoint* point);
+
+    /**
+      @brief Keep the attitude.
+      this method calling in BodyRosJointControllerItem::control.
+     */
+    virtual void keep_attitude();
+
+    /**
+      @brief Call before copy_message.
+     */
+    virtual void start_copy_message();
+
+    /**
+      @brief Copy joint trajectory to inner buffer.
+      this method calling in BodyRosJointControllerItem::receive_message.
+      @param[in] msg Pointer of joint trajectory.
+      @param[in] dst Pointer of inner buffer.
+      @param[in] idx Index of points of currently processing.
+      example:
+      receive message -> ... [ { positons: [ 0.025 ] }, { positions: [ 0.030 ] }, { positions: [ 0.035 ] } ] ...
+      if processing 'positions: [ 0.030 ]', index is setting 1.
+      @param[in] jsz Number of joints.
+      @retval true Apply success.
+      @retval false Apply fail.
+     */
+    virtual bool copy_message(
+                  const trajectory_msgs::JointTrajectoryPoint* msg,
+                  trajectory_msgs::JointTrajectoryPoint* dst,
+                  size_t idx,
+                  unsigned int jsz
+                  );
+
+    /**
+      @brief Call after copy_message.
+     */
+    virtual void end_copy_message();
+};
+
+typedef ref_ptr<BodyRosJointControllerItem> BodyRosJointControllerItemPtr;
+}
+
+#endif  /* CNOID_ROS_PLUGIN_BODY_ROS_JOINT_CONTROLLER_ITEM_H_INCLUDED */

--- a/choreonoid_plugins/src/BodyRosTorqueControllerItem.cpp
+++ b/choreonoid_plugins/src/BodyRosTorqueControllerItem.cpp
@@ -1,0 +1,314 @@
+/**
+  @file
+  @author
+ */
+
+#include "BodyRosTorqueControllerItem.h"
+
+using namespace cnoid;
+
+#if 1  /* Temporary. */
+/* 
+  these parameters are limited. (for JVRC-1)
+  want to outer setting in the future.
+ */
+  
+static const double pgain[] = {
+  50000.0, 30000.0, 30000.0, 30000.0, 30000.0,
+  80000.0, 80000.0, 10000.0, 3000.0,  30000.0,
+  30000.0, 80000.0, 3000.0,  30000.0, 10000.0,
+  3000.0,  3000.0,  30000.0, 30000.0, 10000.0,
+  3000.0,  30000.0, 3000.0,  3000.0,  3000.0,
+  3000.0,  3000.0,  3000.0,  3000.0,  3000.0,
+  3000.0,  3000.0,  10000.0, 3000.0,  3000.0,
+  30000.0, 3000.0,  3000.0,  3000.0,  3000.0,
+  3000.0,  3000.0,  3000.0,  3000.0,
+  };
+  
+static const double dgain[] = {
+  100.0, 100.0, 100.0, 100.0, 100.0,
+  100.0, 100.0, 100.0, 100.0, 100.0,
+  100.0, 100.0, 100.0, 100.0, 100.0,
+  100.0, 100.0, 100.0, 100.0, 100.0,
+  100.0, 100.0, 100.0, 100.0, 100.0,
+  100.0, 100.0, 100.0, 100.0, 100.0,
+  100.0, 100.0, 100.0, 100.0, 100.0,
+  100.0, 100.0, 100.0, 100.0, 100.0,
+  100.0, 100.0, 100.0, 100.0,
+  };
+  
+static const double u_lower[] = {
+  -20.0, -20.0, -20.0, -50.0, -20.0,
+  -50.0, -20.0, -20.0, -20.0, -50.0,
+  -20.0, -50.0, -20.0, -20.0, -20.0,
+  -20.0, -20.0, -20.0, -20.0, -20.0,
+  -20.0, -20.0, -20.0, -20.0, -20.0,
+  -20.0, -20.0, -20.0, -20.0, -20.0,
+  -20.0, -20.0, -20.0, -20.0, -20.0,
+  -20.0, -20.0, -20.0, -20.0, -20.0,
+  -20.0, -20.0, -20.0, -20.0,
+  };
+  
+static const double u_upper[] = {
+  20.0, 20.0, 20.0, 50.0, 20.0,
+  50.0, 20.0, 20.0, 20.0, 50.0,
+  20.0, 50.0, 20.0, 20.0, 20.0,
+  20.0, 20.0, 20.0, 20.0, 20.0,
+  20.0, 20.0, 20.0, 20.0, 20.0,
+  20.0, 20.0, 20.0, 20.0, 20.0,
+  20.0, 20.0, 20.0, 20.0, 20.0,
+  20.0, 20.0, 20.0, 20.0, 20.0,
+  20.0, 20.0, 20.0, 20.0,
+  };
+#endif  /* Temporary. */
+
+void BodyRosTorqueControllerItem::initialize(ExtensionManager* ext) { 
+  static bool initialized = false;
+  int argc = 0;
+  char** argv;
+
+  if (! ros::isInitialized()) {
+    ros::init(argc, argv, "choreonoid");
+  }
+
+  if (! initialized) {
+    ext->itemManager().registerClass<BodyRosTorqueControllerItem>("BodyRosTorqueControllerItem");
+    ext->itemManager().addCreationPanel<BodyRosTorqueControllerItem>();
+    initialized = true;
+  }
+}
+
+BodyRosTorqueControllerItem::BodyRosTorqueControllerItem()
+{
+  controllerTarget         = 0;
+  control_mode_name_       = "torque_control";
+  has_trajectory_          = false;
+  joint_state_update_rate_ = 100.0;
+}
+
+BodyRosTorqueControllerItem::BodyRosTorqueControllerItem(const BodyRosTorqueControllerItem& org)
+  : BodyRosJointControllerItem(org)
+{
+  controllerTarget         = 0;
+  control_mode_name_       = "torque_control";
+  has_trajectory_          = false;
+  joint_state_update_rate_ = 100.0;
+}
+
+BodyRosTorqueControllerItem::~BodyRosTorqueControllerItem()
+{
+  stop();
+}
+
+Item* BodyRosTorqueControllerItem::doDuplicate() const
+{
+  return new BodyRosTorqueControllerItem(*this);
+}
+
+bool BodyRosTorqueControllerItem::hook_of_start()
+{
+#if (DEBUG_ROS_JOINT_CONTROLLER > 0)
+  ROS_DEBUG("%s: Called.", __PRETTY_FUNCTION__);
+#endif  /* DEBUG_ROS_JOINT_CONTROLLER */
+
+#if 1  /* Temporary. */
+  size_t i;
+
+  i = sizeof(pgain) / sizeof(double);
+
+  if (i != body()->numJoints()) {
+    ROS_ERROR("Size mismatch. (pgain %d joint %d)", i, body()->numJoints());
+    return false;
+  }
+
+  i = sizeof(dgain) / sizeof(double);
+
+  if (i != body()->numJoints()) {
+    ROS_ERROR("Size mismatch. (dgain %d joint %d)", i, body()->numJoints());
+    return false;
+  }
+
+  i = sizeof(u_lower) / sizeof(double);
+
+  if (i != body()->numJoints()) {
+    ROS_ERROR("Size mismatch. (u_lower %d joint %d)", i, body()->numJoints());
+    return false;
+  }
+
+  i = sizeof(u_upper) / sizeof(double);
+
+  if (i != body()->numJoints()) {
+    ROS_ERROR("Size mismatch. (u_upper %d joint %d)", i, body()->numJoints());
+    return false;
+  }
+#endif  /* Temporary. */
+
+  qref_old_.resize(body()->numJoints());
+  q_old_.resize(body()->numJoints());
+
+  for (size_t i = 0; i < body()->numJoints(); i++) {
+    qref_old_[i] = body()->joint(i)->q();
+  }
+
+  q_old_ = qref_old_;
+
+  return true;
+}
+
+void BodyRosTorqueControllerItem::pd_control(Link* joint, double q_ref)
+{
+  double q;
+  double dq_ref;
+  double dq;
+  double u;
+  size_t i;
+
+  if (! joint) {
+    ROS_ERROR("%s: Invalid arguments", __PRETTY_FUNCTION__);
+    return;
+  }
+
+  ROS_DEBUG("----- %s (joint id %d) -----", joint->name().c_str(), joint->jointId());
+
+  i = joint->jointId();
+  q = joint->q();
+
+  if (isnan(q_ref)) {
+    ROS_ERROR("Joint angle setting is NaN (%s)", joint->name().c_str());
+    goto done;
+  } else if (q_ref < joint->q_lower() || q_ref > joint->q_upper()) {
+    ROS_ERROR("Joint angle setting is over limit (%s: lower %f upper %f set %f)",
+              joint->name().c_str(), joint->q_lower(), joint->q_upper(), q_ref);
+    goto done;
+  } 
+
+  dq_ref = (q_ref - qref_old_[i]) / timeStep_;
+
+  if (isnan(dq_ref)) {
+    ROS_ERROR("Calculate dq_ref, result is NaN (%s)", joint->name().c_str());
+    goto done;
+  } else if (dq_ref < joint->dq_lower()) {
+    ROS_DEBUG("Calculate dq_ref, result is over lower limt. (adjust %f -> %f)", dq_ref, joint->dq_lower());
+    dq_ref = joint->dq_lower();
+  } else if (dq_ref > joint->dq_upper()) {
+    ROS_DEBUG("Calculate dq_ref, result is over upper limt. (adjust %f -> %f)", dq_ref, joint->dq_upper());
+    dq_ref = joint->dq_upper();
+  }
+
+  dq = (q - q_old_[i]) / timeStep_;
+
+  if (isnan(dq)) {
+    ROS_ERROR("Calculate dq, result is NaN (%s)", joint->name().c_str());
+    goto done;
+  } else if (dq < joint->dq_lower()) {
+    ROS_DEBUG("Calculate dq, result is over lower limt. (adjust %f -> %f)", dq, joint->dq_lower());
+    dq = joint->dq_lower();
+  } else if (dq > joint->dq_upper()) {
+    ROS_DEBUG("Calculate dq, result is over upper limt. (adjust %f -> %f)", dq, joint->dq_upper());
+    dq = joint->dq_upper();
+  }
+
+  u = (q_ref - q) * pgain[i] / 100.0 + (dq_ref - dq) * dgain[i] / 100.0;
+
+  if (! isnan(u)) {
+    if (u < u_lower[i]) {
+      ROS_DEBUG("Calculate u, result is over lower limt. (adjust %f -> %f)", u, u_lower[i]);
+      u = u_lower[i];
+    } else if (u > u_upper[i]) {
+      ROS_DEBUG("Calculate u, result is over upper limt. (adjust %f -> %f)", u, u_upper[i]);
+      u = u_upper[i];
+    }
+
+    ROS_DEBUG("time step %f", timeStep_);
+    ROS_DEBUG("dq_lower %f dq_upper %f", joint->dq_lower(), joint->dq_upper());
+    ROS_DEBUG("pgain %f dgain %f", pgain[i], dgain[i]);
+    ROS_DEBUG("qref_old_ %f q_old_ %f", qref_old_[i], q_old_[i]);
+    ROS_DEBUG("q_ref %f q %f dq_ref %f dq %f u %f", q_ref, q, dq_ref, dq, u);
+
+    joint->u() = u;
+    qref_old_[i] = q_ref;
+  } else {
+    ROS_ERROR("Calculate u, result is NaN (%s)", joint->name().c_str());
+  }
+
+ done:
+  q_old_[i] = q;
+
+  return;
+}
+
+void BodyRosTorqueControllerItem::keep_attitude()
+{
+  for (size_t i = 0; i < body()->numJoints(); i++) {
+    pd_control(body()->joint(i), qref_old_[i]);
+  }
+
+  return;
+}
+
+void BodyRosTorqueControllerItem::apply_message(Link* joint, size_t idx, trajectory_msgs::JointTrajectoryPoint* point)
+{
+  double u;
+
+  if (! joint || ! point) {
+    ROS_ERROR("%s: Invalid arguments", __PRETTY_FUNCTION__);
+    return;
+  }
+
+  if (point->effort.size() < 1) {
+    pd_control(joint, point->positions[idx]);
+  } else {
+    u = point->effort[idx];
+
+    if (! isnan(u)) {
+      joint->u() = u;
+    } else {
+      ROS_ERROR("Effort setting is NaN (%s)", joint->name().c_str());
+    }
+  }
+
+  return;
+}
+
+bool BodyRosTorqueControllerItem::copy_message(
+      const trajectory_msgs::JointTrajectoryPoint* msg,
+      trajectory_msgs::JointTrajectoryPoint* dst,
+      size_t idx,
+      unsigned int jsz
+      )
+{
+  bool has_effort;
+
+  if (! msg || ! dst || jsz < 1) {
+    ROS_ERROR("%s: Invalid arguments", __PRETTY_FUNCTION__);
+    return false;
+  }
+
+  if (msg->velocities.size() > 0 || msg->accelerations.size() > 0) {
+    ROS_WARN("Can not setting velocities and accelerations in this torque controller");
+    return false;
+  }
+
+  dst->positions.resize(jsz);
+
+  if (msg->effort.size() > 0) {
+    dst->effort.resize(jsz);
+    has_effort = true;
+  } else {
+    dst->effort.resize(0);
+    has_effort = false;
+  }
+
+  for (size_t i = 0; i < jsz; i++) {
+    dst->positions[i] = (i < msg->positions.size()) ? msg->positions[i] : 0.0;
+
+    if (has_effort) {
+      dst->effort[i] = (i < msg->effort.size()) ? msg->effort[i] : 0.0;
+    }
+  }
+
+  dst->time_from_start = ros::Duration(msg->time_from_start.sec, msg->time_from_start.nsec);
+
+  return true;
+}
+

--- a/choreonoid_plugins/src/BodyRosTorqueControllerItem.h
+++ b/choreonoid_plugins/src/BodyRosTorqueControllerItem.h
@@ -1,0 +1,44 @@
+/**
+  @file
+  @author
+ */
+
+#ifndef CNOID_ROS_PLUGIN_BODY_ROS_TORQUE_CONTROLLER_ITEM_H_INCLUDED
+#define CNOID_ROS_PLUGIN_BODY_ROS_TORQUE_CONTROLLER_ITEM_H_INCLUDED
+
+#include "BodyRosJointControllerItem.h"
+
+namespace cnoid {
+
+class CNOID_EXPORT BodyRosTorqueControllerItem : public BodyRosJointControllerItem
+{
+public:
+    static void initialize(ExtensionManager* ext);
+    
+    BodyRosTorqueControllerItem();
+    BodyRosTorqueControllerItem(const BodyRosTorqueControllerItem& org);
+    virtual ~BodyRosTorqueControllerItem();
+
+protected:
+    virtual Item* doDuplicate() const;
+    virtual bool hook_of_start();
+    virtual void keep_attitude();
+    virtual void apply_message(Link* joint, size_t idx, trajectory_msgs::JointTrajectoryPoint* point);
+    virtual bool copy_message(
+                  const trajectory_msgs::JointTrajectoryPoint* msg,
+                  trajectory_msgs::JointTrajectoryPoint* dst,
+                  size_t idx,
+                  unsigned int jsz
+                  );
+
+private:
+    std::vector<double> qref_old_;
+    std::vector<double> q_old_;
+
+    void pd_control(Link* joint, double q_ref);
+};
+
+typedef ref_ptr<BodyRosTorqueControllerItem> BodyRosTorqueControllerItemPtr;
+}
+
+#endif  /* CNOID_ROS_PLUGIN_BODY_ROS_TORQUE_CONTROLLER_ITEM_H_INCLUDED */

--- a/choreonoid_plugins/src/RosBodyPlugin.cpp
+++ b/choreonoid_plugins/src/RosBodyPlugin.cpp
@@ -1,4 +1,11 @@
+/**
+  @file
+  @author
+ */
+
 #include "BodyRosItem.h"
+#include "BodyRosTorqueControllerItem.h"
+#include "BodyRosHighgainControllerItem.h"
 #include "WorldRosItem.h"
 #include <cnoid/Plugin>
 
@@ -11,6 +18,8 @@ public:
   
   virtual bool initialize() {
     BodyRosItem::initialize(this);
+    BodyRosTorqueControllerItem::initialize(this);
+    BodyRosHighgainControllerItem::initialize(this);
     WorldRosItem::initialize(this);
     return true;
   }

--- a/choreonoid_plugins/src/WorldRosItem.cpp
+++ b/choreonoid_plugins/src/WorldRosItem.cpp
@@ -55,12 +55,12 @@ void WorldRosItem::start()
   
   world = this->findOwnerItem<WorldItem>();
   if (world)
-    ROS_INFO("Found WorldItem: %s", world->name().c_str());
+    ROS_DEBUG("Found WorldItem: %s", world->name().c_str());
   sim = SimulatorItem::findActiveSimulatorItemFor(this);
   if (sim == 0) return;
   
   std::string name = sim->name();
-  ROS_INFO("Found SimulatorItem: %s", name.c_str());
+  ROS_DEBUG("Found SimulatorItem: %s", name.c_str());
   std::replace(name.begin(), name.end(), '-', '_');
   rosnode_ = boost::shared_ptr<ros::NodeHandle>(new ros::NodeHandle(world->name()));
 
@@ -315,4 +315,6 @@ void WorldRosItem::stop()
       rosnode_->shutdown();
     }
   }
+
+  return;
 }

--- a/choreonoid_plugins/src/python/PyItems.cpp
+++ b/choreonoid_plugins/src/python/PyItems.cpp
@@ -3,6 +3,8 @@
 */
 
 #include "../BodyRosItem.h"
+#include "../BodyRosHighgainControllerItem.h"
+#include "../BodyRosTorqueControllerItem.h"
 #include "../WorldRosItem.h"
 #include <cnoid/BodyState>
 #include <cnoid/PyBase>
@@ -16,7 +18,19 @@ void exportItems()
     ;
   implicitly_convertible<BodyRosItemPtr, ItemPtr>();
   PyItemList<BodyRosItem>("BodyRosItemList");
-  
+
+  class_< BodyRosHighgainControllerItem, BodyRosHighgainControllerItemPtr, bases<Item> >
+    ("BodyRosHighgainControllerItem")
+    ;
+  implicitly_convertible<BodyRosHighgainControllerItemPtr, ItemPtr>();
+  PyItemList<BodyRosHighgainControllerItem>("BodyRosHighgainControllerItemList");
+
+  class_< BodyRosTorqueControllerItem, BodyRosTorqueControllerItemPtr, bases<Item> >
+    ("BodyRosTorqueControllerItem")
+    ;
+  implicitly_convertible<BodyRosTorqueControllerItemPtr, ItemPtr>();
+  PyItemList<BodyRosTorqueControllerItem>("BodyRosTorqueControllerItemList");
+
   class_< WorldRosItem, WorldRosItemPtr, bases<Item> >("WorldRosItem")
     ;
   implicitly_convertible<WorldRosItemPtr, ItemPtr>();

--- a/choreonoid_plugins/test/jvrc1-O1.cnoid
+++ b/choreonoid_plugins/test/jvrc1-O1.cnoid
@@ -300,16 +300,15 @@ items:
           class: AISTSimulatorItem
           data: 
             realtimeSync: true
-            recording: full
-            timeRangeMode: TimeBar range
-            onlyActiveControlPeriod: true
+            recording: "full"
+            timeRangeMode: "Active control period"
             timeLength: 600
             allLinkPositionOutputMode: false
             deviceStateOutput: true
             controllerThreads: true
             recordCollisionData: false
-            dynamicsMode: High-gain dynamics
-            integrationMode: Runge Kutta
+            dynamicsMode: "Forward dynamics"
+            integrationMode: "Runge Kutta"
             gravity: [ 0, 0, -9.80665 ]
             staticFriction: 1
             slipFriction: 1
@@ -370,7 +369,7 @@ items:
               -0.000000, -0.000000, -0.000000,  0.000000, -0.000000, -0.000000, -0.000000,  0.000000, -0.000000,  0.000000, 
                0.000000,  0.000000, -0.000000,  0.000000, -0.000000, -0.000000, -0.000000, -0.000000, -0.000000, -0.000000, 
               -0.000000, -0.000000, -0.000000, -0.000000,  0.000000, -0.000000, -0.000000, -0.000000,  0.000000,  0.000000, 
-               0.000000,  0.000000,  0.000000,  0.000000,  0.000000 ]
+               0.000000,  0.000000,  0.000000,  0.000000 ]
             zmp: [ 0, 0, 0 ]
             collisionDetection: true
             selfCollisionDetection: false
@@ -383,8 +382,15 @@ items:
               class: BodyRosItem
               data: 
                 isImmediateMode: true
+            - 
+              id: 18
+              name: "BodyRosTorqueController"
+              plugin: RosBody
+              class: BodyRosTorqueControllerItem
+              data: 
+                isImmediateMode: true
         - 
-          id: 18
+          id: 19
           name: "WorldRos"
           plugin: RosBody
           class: WorldRosItem
@@ -406,8 +412,7 @@ views:
     class: ItemTreeView
     mounted: true
     state: 
-      selected: [ 16 ]
-      checked: [ 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 18 ]
+      checked: [ 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 18, 19 ]
       expanded: [ 1, 14, 16, 17 ]
   - 
     id: 3
@@ -522,6 +527,8 @@ toolbars:
     speedScale: 1
     syncToOngoingUpdates: true
     autoExpansion: true
+  "BodyBar": 
+    current: 16
   "KinematicsBar": 
     mode: AUTO
     enablePositionDragger: true
@@ -530,8 +537,6 @@ toolbars:
     snapDistance: 0.025
     penetrationBlockDepth: 0.0005
     lazyCollisionDetectionMode: true
-  "BodyBar": 
-    current: 16
   "LeggedBodyBar": 
     stanceWidth: 0.15
   "BodyMotionGenerationBar": 
@@ -647,3 +652,5 @@ Body:
     targetJoints: all
     checkSelfCollisions: true
     onlyTimeBarRange: false
+OpenRTM: 
+  "deleteUnmanagedRTCsOnStartingSimulation": false

--- a/choreonoid_plugins/test/test-jointtrajectory-jvrc-1.py
+++ b/choreonoid_plugins/test/test-jointtrajectory-jvrc-1.py
@@ -3,7 +3,7 @@ import rospy
 from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
 
 def jointtrajectory_publisher():
-    pub = rospy.Publisher('/JVRC_1/set_joint_trajectory', JointTrajectory, queue_size=10)
+    pub = rospy.Publisher('/JVRC_1/highgain_control/set_joint_trajectory', JointTrajectory, queue_size=10)
     rospy.init_node('jvrc1test', anonymous=True)
     r = rospy.Rate(1)
     i = 0

--- a/choreonoid_plugins/test/test-torque-control-jvrc1.py
+++ b/choreonoid_plugins/test/test-torque-control-jvrc1.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+#
+#
+
+import sys
+import os
+import math
+import rospy 
+from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
+
+#
+# Functions.
+#
+
+#
+def publish_jvrc1_jointtrajectory(jname='NECK_Y', jdegree=0):
+    rad = float('{0:.4f}'.format(math.radians(float(jdegree))))
+    pub = rospy.Publisher('/JVRC_1/torque_control/set_joint_trajectory', JointTrajectory, latch=True, queue_size=10)
+    rospy.init_node('jvrc1_choreonoid_ros_test', anonymous=True)
+    msg = JointTrajectory()
+    msg.joint_names = [ jname ]
+    msg.points = []
+    p = JointTrajectoryPoint()
+    p.time_from_start = rospy.rostime.Duration(0)
+    p.positions = [ rad ]
+
+    msg.points.append(p)
+    rospy.loginfo(msg)
+    pub.publish(msg)
+    rospy.Rate(1).sleep()
+
+#
+def check_jvrc1_joint_name(jname=''):
+    names = { 
+        'R_HIP_P': 0,      'R_HIP_R': 0,      'R_HIP_Y': 0,      'R_KNEE': 0,       'R_ANKLE_R': 0,
+        'R_ANKLE_P': 0,    'L_HIP_P': 0,      'L_HIP_R': 0,      'L_HIP_Y': 0,      'L_KNEE': 0,
+        'L_ANKLE_R': 0,    'L_ANKLE_P': 0,    'WAIST_Y': 0,      'WAIST_P': 0,      'WAIST_R': 0,
+        'NECK_Y': 0,       'NECK_R': 0,       'NECK_P': 0,       'R_SHOULDER_P': 0, 'R_SHOULDER_R': 0,
+        'R_SHOULDER_Y': 0, 'R_ELBOW_P': 0,    'R_ELBOW_Y': 0,    'R_WRIST_R': 0,    'R_WRIST_Y': 0,
+        'R_UTHUMB': 0,     'R_LTHUMB': 0,     'R_UINDEX': 0,     'R_LINDEX': 0,     'R_ULITTLE': 0,
+        'R_LLITTLE': 0,    'L_SHOULDER_P': 0, 'L_SHOULDER_R': 0, 'L_SHOULDER_Y': 0, 'L_ELBOW_P': 0,
+        'L_ELBOW_Y': 0,    'L_WRIST_R': 0,    'L_WRIST_Y': 0,    'L_UTHUMB': 0,     'L_LTHUMB': 0,
+        'L_UINDEX': 0,     'L_LINDEX': 0,     'L_ULITTLE': 0,    'L_LLITTLE': 0
+        } 
+
+    return jname in names
+
+#
+def usage():
+    name = os.path.basename(sys.argv[0])
+
+    print 'usage: ' + name + ' [joint name] [joint angle (degree)]'
+    print ''
+    print 'Set joint angle for JVRC-1 robot.'
+    print ''
+    print '[joint name] setting choose one of them:'
+    print '  R_HIP_P      R_HIP_R      R_HIP_Y      R_KNEE       R_ANKLE_R,'
+    print '  R_ANKLE_P    L_HIP_P      L_HIP_R      L_HIP_Y      L_KNEE'
+    print '  L_ANKLE_R    L_ANKLE_P    WAIST_Y      WAIST_P      WAIST_R'
+    print '  NECK_Y       NECK_R       NECK_P       R_SHOULDER_P R_SHOULDER_R'
+    print '  R_SHOULDER_Y R_ELBOW_P    R_ELBOW_Y    R_WRIST_R    R_WRIST_Y'
+    print '  R_UTHUMB     R_LTHUMB     R_UINDEX     R_LINDEX     R_ULITTLE'
+    print '  R_LLITTLE    L_SHOULDER_P L_SHOULDER_R L_SHOULDER_Y L_ELBOW_P'
+    print '  L_ELBOW_Y    L_WRIST_R    L_WRIST_Y    L_UTHUMB     L_LTHUMB'
+    print '  L_UINDEX     L_LINDEX     L_ULITTLE    L_LLITTLE'
+    print ''
+    print '[joint angle] setting is range from 360.0 to -360.0.'
+    print ''
+    print 'e.g. if you want to change the joint angle of the NECK_Y to dgree of 40.'
+    print '  ' + name + ' NECK_Y 40.0'
+    print ''
+
+    return
+
+# 
+# Main.  
+#
+
+if __name__ == '__main__':
+    is_error = True
+
+    try:
+        if len(sys.argv) == 3:
+            s = sys.argv[1]
+            f = float(sys.argv[2])
+
+            if (check_jvrc1_joint_name(s) and (f <= 360.0 and f >= -360.0)):
+                publish_jvrc1_jointtrajectory(jname=s, jdegree=f)
+                is_error = False
+    except ValueError:
+        pass
+    except rospy.ROSInterruptException:
+        pass
+
+    if (is_error):
+        usage()
+        sys.exit(1)
+
+    sys.exit(0)

--- a/choreonoid_ros/launch/jvrc-1-rviz.launch
+++ b/choreonoid_ros/launch/jvrc-1-rviz.launch
@@ -5,7 +5,7 @@
     <arg name="PROJECT_FILE" default="$(find choreonoid_plugins)/test/jvrc1-O1.cnoid" />
   </include>
   <node pkg="robot_state_publisher" type="robot_state_publisher" name="jvrc_1_state_publisher" >
-    <remap from="joint_states" to="/JVRC_1/joint_states" />
+    <remap from="joint_states" to="/JVRC_1/torque_control/joint_states" />
   </node>
   <node name="jvrc_1_rviz" pkg="rviz" type="rviz" respawn="true"
         args="-sync -d $(find choreonoid_ros)/launch/jvrc-1.rviz" />


### PR DESCRIPTION
BodyRosItem からジョイントコントローラを分離、トルク制御用とハイゲイン制御用の 2 つのコントローラを新たに用意しました。
また、チュートリアル用のプロジェクトを、今回の内容に合わせ修正しました。

現在認識している問題として、トルク制御用のコントローラが JVRC-1 モデル専用となっている問題があります。
