### PR TITLE
can setting the CMake at build of the Choreonoid

### DIFF
--- a/choreonoid_ros/CMakeLists.txt
+++ b/choreonoid_ros/CMakeLists.txt
@@ -9,7 +9,7 @@ catkin_package(DEPENDS eigen)
 execute_process(
     COMMAND
     ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR}
-    make -f ${PROJECT_SOURCE_DIR}/Makefile.choreonoid INSTALL_DIR=${CATKIN_DEVEL_PREFIX} installed.choreonoid
+    make -f ${PROJECT_SOURCE_DIR}/Makefile.choreonoid INSTALL_DIR=${CATKIN_DEVEL_PREFIX} CMD_SETTING_BUILD_ARGS=${PROJECT_SOURCE_DIR}/setting_build_args.sh installed.choreonoid
     RESULT_VARIABLE
     _make_failed
 )

--- a/choreonoid_ros/Makefile.choreonoid
+++ b/choreonoid_ros/Makefile.choreonoid
@@ -11,7 +11,8 @@ installed.choreonoid: $(GIT_DIR)
 	@echo "                 PATH=$(PATH)"
 	@echo "                 INSTALL_DIR=$(INSTALL_DIR)"
 	@echo "                 GIT_DIR=$(GIT_DIR)"
-	cd $(GIT_DIR) && cmake . -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR) -DENABLE_INSTALL_RPATH=ON -DENABLE_PYTHON=ON && make -j 4 && make install
+	@echo "                 CMD_SETTING_BUILD_ARGS=$(CMD_SETTING_BUILD_ARGS)"
+	cd $(GIT_DIR) && cmake . -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR) $(shell $(CMD_SETTING_BUILD_ARGS) cmake) && make $(shell $(CMD_SETTING_BUILD_ARGS) make) && make install
 	touch installed.choreonoid
 
 clean.choreonoid:

--- a/choreonoid_ros/package.xml
+++ b/choreonoid_ros/package.xml
@@ -69,7 +69,7 @@ following libraries:
 * Bullet Physics Library (http://bulletphysics.org/)
 * omniORB (http://omniorb.sourceforge.net/)
 * OpenRTM-aist (http://openrtm.org/)
-	</description>
+  </description>
   <maintainer email="f-kanehiro@aist.go.jp">Fumio Kanehiro</maintainer>
 
   <license>MIT</license>
@@ -82,27 +82,27 @@ following libraries:
 
   <buildtool_depend>catkin</buildtool_depend>
 
-	<build_depend>cmake</build_depend>
-	<build_depend>boost</build_depend>
-	<build_depend>eigen</build_depend>
-	<build_depend>libqt4-dev</build_depend>
-	<build_depend>libqt4-opengl-dev</build_depend>
-	<build_depend>qt4-dev-tools</build_depend>
-	<build_depend>libglew-dev</build_depend>
-	<build_depend>yaml</build_depend>
-	<build_depend>zlib</build_depend>
-	<build_depend>libjpeg</build_depend>
-	<build_depend>libpng12-dev</build_depend>
-	<build_depend>opende</build_depend>
-	<build_depend>omniorb</build_depend>
-	<build_depend>python-omniorb</build_depend>
-	<build_depend>libgstreamer0.10-dev</build_depend>
-	<build_depend>libgstreamer-plugins-base0.10-dev</build_depend>
-	<build_depend>libpulse-dev</build_depend>
-	<build_depend>libsndfile1-dev</build_depend>
-	<build_depend>python</build_depend>
-	<build_depend>python-numpy</build_depend>
-	<build_depend>uuid</build_depend>
+  <build_depend>cmake</build_depend>
+  <build_depend>boost</build_depend>
+  <build_depend>eigen</build_depend>
+  <build_depend>libqt4-dev</build_depend>
+  <build_depend>libqt4-opengl-dev</build_depend>
+  <build_depend>qt4-dev-tools</build_depend>
+  <build_depend>libglew-dev</build_depend>
+  <build_depend>yaml</build_depend>
+  <build_depend>zlib</build_depend>
+  <build_depend>libjpeg</build_depend>
+  <build_depend>libpng12-dev</build_depend>
+  <build_depend>opende</build_depend>
+  <build_depend>omniorb</build_depend>
+  <build_depend>python-omniorb</build_depend>
+  <build_depend>libgstreamer0.10-dev</build_depend>
+  <build_depend>libgstreamer-plugins-base0.10-dev</build_depend>
+  <build_depend>libpulse-dev</build_depend>
+  <build_depend>libsndfile1-dev</build_depend>
+  <build_depend>python</build_depend>
+  <build_depend>python-numpy</build_depend>
+  <build_depend>uuid</build_depend>
 
   <build_depend>doxygen</build_depend>
   <build_depend>mk</build_depend>

--- a/choreonoid_ros/setting_build_args.sh
+++ b/choreonoid_ros/setting_build_args.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# This script is setting CMake arguments for build of the Choreonoid.
+#
+
+#
+# Variables.
+#
+
+# for cmake
+_CNOID_ROS_PKG_BUILD_CNOID_USER_CMAKE_ARGS=""
+_CNOID_ROS_PKG_BUILD_CNOID_CONSTANT_CMAKE_ARGS="
+  -DENABLE_INSTALL_PATH=ON
+  -DENABLE_PYTHON=ON
+  "
+
+# for make
+_CNOID_ROS_PKG_BUILD_CNOID_MAKE_ARGS="-j 4"
+
+#
+# Main.
+#
+
+_dir=`dirname ${0}`
+_fname=""
+
+case ${1} in
+  cmake)
+    _fname="${_dir}/additional_cmake_args"
+
+    if [ -f ${_fname} ]; then
+      _CNOID_ROS_PKG_BUILD_CNOID_USER_CMAKE_ARGS=`cat ${_fname}`
+    fi
+
+    echo ${_CNOID_ROS_PKG_BUILD_CNOID_CONSTANT_CMAKE_ARGS} ${_CNOID_ROS_PKG_BUILD_CNOID_USER_CMAKE_ARGS}
+    ;;
+
+  make)
+    _fname="${_dir}/additional_make_args"
+
+    if [ -f ${_fname} ]; then
+      _CNOID_ROS_PKG_BUILD_CNOID_MAKE_ARGS=`cat ${_fname}`
+    fi
+
+    echo ${_CNOID_ROS_PKG_BUILD_CNOID_MAKE_ARGS}
+    ;;
+
+  *)
+    echo "usage:" `basename ${0}` "[ cmake | make ]"  
+    exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
choreonoid_ros の Choreonoid ビルド時に CMake 設定を可能としました。
~/catkin_ws/src/choreonoid_ros_pkg/choreonoid_ros ディレクトリ下に、additional_cmake_args ファイルを作成し、当該ファイルへ CMake への設定を記述します。

例：

以下は、OpenRTM プラグインを有効化する場合の additional_cmake_args ファイルの内容です。

```
-DENABLE_CORBA=ON -DBUILD_CORBA_PLUGIN=ON -DBUILD_OPENRTM_PLUGIN=ON -DBUILD_OPENRTM_SAMPLES=ON
```
