### PR TITLE
updates for environment of Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,14 @@ before_install:
   - export CI_SOURCE_PATH=$(pwd)
   - export REPOSITORY_NAME=${PWD##*/}
   - echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
-  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
+  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+  - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net --recv-key 0xB01FA116
   - sudo add-apt-repository ppa:hrg/daily -y
   - sudo apt-get update -qq
-  - sudo apt-get install -qq -y python-catkin-pkg python-catkin-tools python-rosdep python-wstool python-setuptools openhrp meshlab imagemagick python-omniorb openrtm-aist-python python-numpy
+  - sudo apt-get install -qq -y python-catkin-tools python-rosdep python-wstool python-setuptools openhrp meshlab imagemagick python-omniorb openrtm-aist-python python-numpy
   - sudo easy_install pip
-  - sudo pip install --upgrade pip
-  - sudo pip install enum34
+  - sudo -H pip install --upgrade pip
+  - sudo -H pip install enum34
   - sudo rosdep init
   - rosdep update
 install:
@@ -32,12 +32,12 @@ install:
   - ln -s $CI_SOURCE_PATH .
   - cd ../
   - catkin init
-  - catkin config --install
+  - catkin config --merge-devel --install
   - rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
   - cd ~/
   - git clone https://github.com/fkanehiro/simtrans.git
   - cd simtrans
-  - sudo pip install -r requirements.txt
+  - sudo -H pip install -r requirements.txt
   - sudo python setup.py install
   - cd ../
 before_script:

--- a/choreonoid_plugins/CMakeLists.txt
+++ b/choreonoid_plugins/CMakeLists.txt
@@ -1,4 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
+cmake_policy(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
+
+if (CMAKE_VERSION VERSION_GREATER "2.9.9.9")
+  cmake_policy(SET CMP0037 OLD)
+endif()
+
 project(choreonoid_plugins)
 
 find_package(catkin REQUIRED COMPONENTS 
@@ -28,7 +34,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 include (FindPkgConfig)
-set(ENV{PKG_CONFIG_PATH} $ENV{PKG_CONFIG_PATH}:${CATKIN_DEVEL_PREFIX}/lib/pkgconfig)
+set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${CATKIN_DEVEL_PREFIX}/lib/pkgconfig")
 if (PKG_CONFIG_FOUND)
   pkg_check_modules(CNOID REQUIRED choreonoid)
 else()

--- a/choreonoid_plugins/package.xml
+++ b/choreonoid_plugins/package.xml
@@ -16,8 +16,8 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>choreonoid_ros</build_depend>
-	<build_depend>boost</build_depend>
-	<build_depend>eigen</build_depend>
+  <build_depend>boost</build_depend>
+  <build_depend>eigen</build_depend>
   <build_depend>gazebo_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>

--- a/choreonoid_ros/CMakeLists.txt
+++ b/choreonoid_ros/CMakeLists.txt
@@ -1,5 +1,11 @@
 # http://ros.org/doc/hydro/api/catkin/html/user_guide/supposed.html
 cmake_minimum_required(VERSION 2.8.3)
+cmake_policy(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
+
+if (CMAKE_VERSION VERSION_GREATER "2.9.9.9")
+  cmake_policy(SET CMP0037 OLD)
+endif()
+
 project(choreonoid_ros)
 
 find_package(catkin REQUIRED COMPONENTS mk)


### PR DESCRIPTION
Travis CI 環境の Ubuntu 14.04 でビルドに失敗する問題への対応を実施しました。
また、同環境の cmake は Ubuntu 14.04 標準の 2.8 系ではなく 3.2 系となっており、こちらへの対応も併せて実施しました。
