### PR TITLE
fixes wrong use of limit values of the joint angular velocity

### DIFF
--- a/choreonoid_plugins/src/BodyRosTorqueControllerItem.h
+++ b/choreonoid_plugins/src/BodyRosTorqueControllerItem.h
@@ -48,6 +48,11 @@ private:
     std::vector<double> qref_old_;
     std::vector<double> q_old_;
 
+    /// Lower limit of joint anglur velocity. (per timeStep_)
+    std::vector<double> dq_llimit_ts_;
+    /// Upper limit of joint anglur velocity. (per timeStep_)
+    std::vector<double> dq_ulimit_ts_;
+
     /**
      */
     bool set_pdc_parameters(Listing* src, std::vector<double>& dst);


### PR DESCRIPTION
コントローラ内の関節制御において、関節角速度制限の値 [rad/s] をシミュレーションの実行周期で時分割せず、そのまま使用していた不具合を修正しました。
