### PR TITLE
add new hook at start of simulation

### DIFF
--- a/choreonoid_plugins/src/BodyRosJointControllerItem.cpp
+++ b/choreonoid_plugins/src/BodyRosJointControllerItem.cpp
@@ -58,6 +58,15 @@ bool BodyRosJointControllerItem::hook_of_start()
   return true;
 }
 
+bool BodyRosJointControllerItem::hook_of_start_at_after_creation_rosnode()
+{
+#if (DEBUG_ROS_JOINT_CONTROLLER > 0)
+  ROS_DEBUG("%s: Called", __PRETTY_FUNCTION__);
+#endif  /* DEBUG_ROS_JOINT_CONTROLLER */
+
+  return true;
+}
+
 bool BodyRosJointControllerItem::start(Target* target)
 {
   std::string topic_name;
@@ -98,6 +107,10 @@ bool BodyRosJointControllerItem::start(Target* target)
   topic_name                 = control_mode_name_ + "/set_joint_trajectory";
   joint_state_subscriber_    = rosnode_->subscribe(
                                           topic_name, 1000, &BodyRosJointControllerItem::receive_message, this);
+
+  if (hook_of_start_at_after_creation_rosnode() == false) {
+    return false;
+  }
 
   async_ros_spin_.reset(new ros::AsyncSpinner(0));
   async_ros_spin_->start();

--- a/choreonoid_plugins/src/BodyRosJointControllerItem.h
+++ b/choreonoid_plugins/src/BodyRosJointControllerItem.h
@@ -109,11 +109,20 @@ protected:
 
     /*
       @brief Hook of simulation start.
-      this method calling in BodyRosJointControllerItem::start.
+      This method calling in BodyRosJointControllerItem::start.
       @retval true Start controller.
       @retval false Stop controller.
      */
     virtual bool hook_of_start();
+
+    /*
+      @brief Hook of simulation start at after creation of the ROS node handle.
+      This method calling in BodyRosJointControllerItem::start.
+      This method can make use of the ROS node handler of 'rosnode_'.
+      @retval true Start controller.
+      @retval false Stop controller.
+     */
+    virtual bool hook_of_start_at_after_creation_rosnode();
 
     /**
       @brief Apply joint trajectory of inner buffer.


### PR DESCRIPTION
シミュレーション開始時に ROS トピックの追加等を行えるようにするため、ros::NodeHandler 生成後に呼び出されるフックを追加しました。