### PR TITLE
specified the CMake 'CMAKE_BUILD_TYPE Release' option

### DIFF
--- a/choreonoid_plugins/CMakeLists.txt
+++ b/choreonoid_plugins/CMakeLists.txt
@@ -11,6 +11,12 @@ endif()
 
 project(choreonoid_plugins)
 
+# NOTE: if you chosen the CMake build type with not set optimize option of compiler,
+# the depth camera device process very slowly.
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
 find_package(catkin REQUIRED COMPONENTS 
   choreonoid_ros
   message_generation 


### PR DESCRIPTION
ビルドのデフォルトを CMAKE_BUILD_TYPE Release に変更しました。

コンパイラの最適化オプションの指定が無い場合、RangeCamera デバイスの処理速度低下が著しい事が当該変更理由となります。