### PR TITLE
use ros::spinOnce to publish on each simulation loops and debug (ref …

### DIFF
--- a/choreonoid_plugins/src/WorldRosItem.h
+++ b/choreonoid_plugins/src/WorldRosItem.h
@@ -94,27 +94,22 @@ private:
     WorldItemPtr world;
     SimulatorItemPtr sim;
     boost::shared_ptr<ros::NodeHandle> rosnode_;
-    boost::shared_ptr<ros::AsyncSpinner> async_ros_spin_;
     ros::CallbackQueue rosqueue_;
     boost::shared_ptr<boost::thread> rosqueue_thread_;
 
-    /**
-       The variable for managing registration to the simulator item.
-       This registration that function of node creation at the simulation start,
-       node deletion at the simulation stop.
-     */
-    std::map<SimulatorItemPtr, std::string> registration_node_management_;
-
     /// The registration id of calling function from physics engine. (physics engine is SimulatorItem's subclass)
-    std::list<int> post_dynamics_function_regid;
+    int post_dynamics_function_regid;
 
     void queueThread();
 
+    std::map<std::string, bool> hooked_simulators_;
+
     /**
-      @brief Connect to event signal, function of nodes creation and deletion.
-      The event signal is 'RootItem::instace()->sigTreeChanged()'.
+      @brief Hook simulation start and stop event
      */
-    void registrationNodeStartAndStop();
+    void hookSimulationStartAndStopEvent();
+
+    void onPostDynamics();
 
     /*
       For services and topics.

--- a/choreonoid_plugins/src/WorldRosItem.h
+++ b/choreonoid_plugins/src/WorldRosItem.h
@@ -94,13 +94,10 @@ private:
     WorldItemPtr world;
     SimulatorItemPtr sim;
     boost::shared_ptr<ros::NodeHandle> rosnode_;
-    ros::CallbackQueue rosqueue_;
-    boost::shared_ptr<boost::thread> rosqueue_thread_;
+    boost::shared_ptr<ros::AsyncSpinner> async_ros_spin_;
 
     /// The registration id of calling function from physics engine. (physics engine is SimulatorItem's subclass)
     int post_dynamics_function_regid;
-
-    void queueThread();
 
     std::map<std::string, bool> hooked_simulators_;
 


### PR DESCRIPTION
ros::spinOnceを使って各シミュレーションループに同期して（シミュレーションスレッド上で）メッセージをpublishするようにしました。

publish間隔を決定する変数の初期値が常に0になってしまっており、これだとシミュレーションを途中から開始したときに異常な動作をすると思われるのでデバッグもしてあります。

ref #91